### PR TITLE
Fix export / import statements under node 4.1.1

### DIFF
--- a/module/index.js
+++ b/module/index.js
@@ -15,7 +15,7 @@
   * @function  default
   * @alias     isSubset
   */
-const isSubset = (superset, subset) => {
+export function isSubset(superset, subset) {
   if (
     (typeof superset !== 'object' || superset === null) ||
     (typeof subset !== 'object' || subset === null)
@@ -34,6 +34,4 @@ const isSubset = (superset, subset) => {
 
     return true;
   });
-};
-
-export {isSubset as default};
+}

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 import test from 'tape-catch';
 
-import isSubset from './module';
+import { isSubset } from './module';
 
 test('Detects shallow subsets.', (is) => {
   is.ok(isSubset(


### PR DESCRIPTION
Couldn't get the project tests to run using my version of Node.  Ended up trying v0.10.40, v0.12.7 and v4.1.1 without any success.

The problem seemed to be around the exports / imports.  In module.js it is doing an export *, which according to the documentation (http://exploringjs.com/es6/ch_modules.html#leanpub-auto-re-exporting) doesn't export the default function.

I've therefore fixed the code and now works on v0.10.40, v0.12.7 and v4.1.1.
