### PR TITLE
Fix files section

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,14 +27,6 @@
   , "tape-catch": "1.0.4"
   }
 
-, "files":
-  [ "/*.js"
-  , "/module/"
-  , "/test/"
-  , "/Readme.md"
-  , "/License.md"
-  ]
-
 , "license": "MIT"
 , "keywords":
   [ "contains"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 { "name": "is-subset"
-, "version": "0.1.1"
+, "version": "0.1.2"
 , "description": "Check if an object is contained within another one"
 
 , "dependencies":

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 { "name": "is-subset"
-, "version": "0.1.2"
+, "version": "0.1.1"
 , "description": "Check if an object is contained within another one"
 
 , "dependencies":

--- a/package.json
+++ b/package.json
@@ -27,6 +27,13 @@
   , "tape-catch": "1.0.4"
   }
 
+, "files":
+  [  "index.js"
+,   "module"
+,   "module.js"
+,   "Readme.md"
+,   "License.md"
+  ]
 , "license": "MIT"
 , "keywords":
   [ "contains"


### PR DESCRIPTION
When using [pkg](https://github.com/zeit/pkg) the files section of is-subset causes the packaging process to attempt a crawl over the root directory. This obviously breaks with permissions issues.

This PR replaces the files section with something more targeted.